### PR TITLE
PR-03: feat: Create UI Components in components/

### DIFF
--- a/src/components/ui/CategoryButton.tsx
+++ b/src/components/ui/CategoryButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface CategoryButtonProps {
+  id: string;
+  label: string;
+  icon: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export default function CategoryButton({ id, label, icon, isSelected, onClick }: CategoryButtonProps) {
+  return (
+    <button 
+      type="button" 
+      onClick={onClick}
+      className={`group flex flex-col items-center justify-center p-4 bg-surface-container-low rounded-xl border-2 transition-all ${
+        isSelected 
+          ? 'border-secondary bg-secondary/10' 
+          : 'border-transparent hover:border-secondary hover:bg-secondary/5'
+      }`}
+    >
+      <span className={`material-symbols-outlined mb-2 transition-colors ${
+        isSelected ? 'text-secondary' : 'text-outline group-hover:text-secondary'
+      }`}>
+        {icon}
+      </span>
+      <span className={`text-[10px] font-bold transition-colors ${
+        isSelected ? 'text-secondary' : 'text-on-surface-variant group-hover:text-secondary'
+      }`}>
+        {label}
+      </span>
+    </button>
+  );
+}

--- a/src/components/ui/ColorSwatch.tsx
+++ b/src/components/ui/ColorSwatch.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface ColorSwatchProps {
+  colorClass: string;
+  isSelected: boolean;
+  onClick: () => void;
+}
+
+export default function ColorSwatch({ colorClass, isSelected, onClick }: ColorSwatchProps) {
+  return (
+    <div 
+      onClick={onClick}
+      className={`w-8 h-8 rounded-full ${colorClass} cursor-pointer transition-all ${
+        colorClass === 'bg-white' ? 'border border-outline-variant' : ''
+      } ${
+        isSelected 
+          ? 'ring-2 ring-offset-2 ring-primary scale-110' 
+          : 'ring-2 ring-offset-2 ring-transparent hover:ring-outline-variant'
+      }`}
+    />
+  );
+}

--- a/src/components/ui/EntryForm.tsx
+++ b/src/components/ui/EntryForm.tsx
@@ -1,5 +1,6 @@
 "use client";
-
+import CategoryButton from './CategoryButton';
+import ColorSwatch from './ColorSwatch';
 import { useState } from "react";
 
 export default function EntryForm() {
@@ -83,27 +84,14 @@ export default function EntryForm() {
             </label>
             <div className="grid grid-cols-4 gap-4">
               {categories.map((cat) => (
-                <button 
+                <CategoryButton 
                   key={cat.id}
-                  type="button" 
+                  id={cat.id}
+                  label={cat.label}
+                  icon={cat.icon}
+                  isSelected={selectedCategory === cat.id}
                   onClick={() => setSelectedCategory(cat.id)}
-                  className={`group flex flex-col items-center justify-center p-4 bg-surface-container-low rounded-xl border-2 transition-all ${
-                    selectedCategory === cat.id 
-                      ? 'border-secondary bg-secondary/10' 
-                      : 'border-transparent hover:border-secondary hover:bg-secondary/5'
-                  }`}
-                >
-                  <span className={`material-symbols-outlined mb-2 transition-colors ${
-                    selectedCategory === cat.id ? 'text-secondary' : 'text-outline group-hover:text-secondary'
-                  }`}>
-                    {cat.icon}
-                  </span>
-                  <span className={`text-[10px] font-bold transition-colors ${
-                    selectedCategory === cat.id ? 'text-secondary' : 'text-on-surface-variant group-hover:text-secondary'
-                  }`}>
-                    {cat.label}
-                  </span>
-                </button>
+                  />
               ))}
             </div>
           </div>
@@ -131,17 +119,12 @@ export default function EntryForm() {
             </label>
             <div className="flex flex-wrap gap-3">
               {colors.map((colorClass, idx) => (
-                <div 
-                  key={idx}
-                  onClick={() => setSelectedColor(colorClass)}
-                  className={`w-8 h-8 rounded-full ${colorClass} cursor-pointer transition-all ${
-                    colorClass === 'bg-white' ? 'border border-outline-variant' : ''
-                  } ${
-                    selectedColor === colorClass 
-                      ? 'ring-2 ring-offset-2 ring-primary scale-110' 
-                      : 'ring-2 ring-offset-2 ring-transparent hover:ring-outline-variant'
-                  }`}
-                />
+              <ColorSwatch 
+                key={idx}
+                colorClass={colorClass}
+                isSelected={selectedColor === colorClass}
+                onClick={() => setSelectedColor(colorClass)}
+              />
               ))}
             </div>
           </div>

--- a/src/components/ui/ItemCard.tsx
+++ b/src/components/ui/ItemCard.tsx
@@ -1,3 +1,5 @@
+import StatusBadge from './StatusBadge';
+
 interface ItemCardProps {
   status: 'Found' | 'Lost';
   icon: string;
@@ -9,7 +11,7 @@ interface ItemCardProps {
 }
 
 export default function ItemCard({ status, icon, placeholderIcon, placeholderText, title, location, reference }: ItemCardProps) {
-  const isFound = status === 'Found';
+
 
   return (
     <div className="bg-surface-container-lowest p-6 rounded-xl group hover:-translate-y-1 transition-all duration-300 shadow-sm hover:shadow-md">
@@ -17,11 +19,7 @@ export default function ItemCard({ status, icon, placeholderIcon, placeholderTex
         <div className="w-12 h-12 bg-surface-container-low flex items-center justify-center rounded-lg">
           <span className="material-symbols-outlined text-primary-container">{icon}</span>
         </div>
-        <span className={`text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded ${
-          isFound ? 'text-on-tertiary-container bg-tertiary-fixed' : 'text-white bg-[#ba1a1a]' // Used standard red/error for lost
-        }`}>
-          {status}
-        </span>
+        <StatusBadge status={status} />
       </div>
       
       <div className="space-y-4 mb-8">

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface StatusBadgeProps {
+  status: 'Found' | 'Lost';
+}
+
+export default function StatusBadge({ status }: StatusBadgeProps) {
+  const isFound = status === 'Found';
+  
+  return (
+    <span className={`text-[10px] font-bold uppercase tracking-widest px-2 py-1 rounded ${
+      isFound ? 'text-on-tertiary-container bg-tertiary-fixed' : 'text-white bg-[#ba1a1a]'
+    }`}>
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
## What Changed:
* **New Components:** Created `StatusBadge.tsx`, `CategoryButton.tsx`, and `ColorSwatch.tsx` in the `src/components/` directory.
* **Refactor:** Updated `ItemCard.tsx` to replace hardcoded status spans with the new `StatusBadge` component.
* **Refactor:** Updated `EntryForm.tsx` to replace inline mapping of categories and colors with `CategoryButton` and `ColorSwatch`.
* **TypeScript:** Implemented strict interfaces for all new components to handle selection states and dynamic styling.

## Why:
* **Individual Deliverable:** Fulfills the "Role 3 - UX/UI Designer" requirement to translate wireframes into reusable front-end components (Atoms/Molecules).
* **KM Requirement (Externalization):** Standardizes the intake process by forcing users to select from a fixed taxonomy (Icon Grid & Color Palette), which solves the "Vocabulary Gap" identified in the framework selection.
* **GitHub Rules:** Ensures I meet the requirement of having at least 3 front-end component commits on my feature branch (`ortiz-ui`) and fulfills the mandatory Pull Request requirement per sprint.

## How to Test:
1.  **Run the App:** Navigate to the **Public Board** and check if the `ItemCard` displays the "Lost" (Red) or "Found" (Aqua) status correctly via the `StatusBadge`.
2.  **Form Interaction:** Open the **Create Entry** form and verify that clicking a `CategoryButton` or `ColorSwatch` correctly updates the visual focus (ring/border) and stores the selected state.
3.  **Code Audit:** Verify that `EntryForm.tsx` and `ItemCard.tsx` no longer contain long blocks of repetitive HTML for buttons and instead use the imported modular components.